### PR TITLE
Add icon button title text

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -90,13 +90,15 @@ const { toggleTheme, isDarkTheme } = useTheme(themeService);
               "
             />
             <IconButtonContainer>
-              <IconButton @click="toggleSort">
+              <IconButton title="Sort List" @click="toggleSort">
                 {{ isSorting ? Icon.Descending : Icon.Ascending }}
               </IconButton>
-              <IconButton @click="toggleFilter">
+              <IconButton title="Filter List" @click="toggleFilter">
                 {{ isFiltering ? Icon.Favorite : Icon.NotFavorite }}
               </IconButton>
-              <IconButton @click="addBookmark()">{{ Icon.Add }}</IconButton>
+              <IconButton title="Add Bookmark" @click="addBookmark()">{{
+                Icon.Add
+              }}</IconButton>
             </IconButtonContainer>
           </CommandPaletteControls>
           <List :items="bookmarks">

--- a/src/components/IconButton.vue
+++ b/src/components/IconButton.vue
@@ -1,8 +1,11 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+defineProps<{ title: string }>();
+</script>
 <template>
   <button
     class="hover:bg-stone-300 dark:hover:bg-gray-700 rounded-lg py-2 px-3"
     type="button"
+    :title="title"
   >
     <slot />
   </button>

--- a/src/components/ListItem.vue
+++ b/src/components/ListItem.vue
@@ -34,11 +34,15 @@ defineEmits<{
         </div>
       </template>
       <template v-else>
-        <IconButton @click="$emit('favorite-clicked', bookmark.id)">
+        <IconButton
+          title="Favorite Bookmark"
+          @click="$emit('favorite-clicked', bookmark.id)"
+        >
           {{ bookmark.isFavorite ? Icon.Favorite : Icon.NotFavorite }}
         </IconButton>
         <IconButton
           v-if="!isEditing"
+          title="Edit Bookmark"
           @click="$emit('edit-clicked', bookmark.id)"
         >
           {{ Icon.Pencil }}


### PR DESCRIPTION
This change introduces a required title prop to the icon button component and uses it to add title/hover text to icon buttons.

Testing Instructions
---
1. Open 'marks
1. Hover the sort, filter, add, favorite, and edit icon buttons
    - [x] Verify that the buttons have relevant title text

Acceptance Criteria
---
When I hover over an icon button:
- I can see text explaining what the button is for.