### PR TITLE
Add recently used sort

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,8 @@
     "": {
       "version": "0.0.1",
       "dependencies": {
+        "@vueuse/components": "^8.9.4",
+        "@vueuse/core": "^8.9.4",
         "vue": "^3.2.16"
       },
       "devDependencies": {
@@ -501,6 +503,11 @@
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true
     },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.14.tgz",
+      "integrity": "sha512-5d2RhCard1nQUC3aHcq/gHzWYO6K0WJmAbjO7mQJgCQKtZpgXxv1rOM6O/dBDhDYYVutk1sciOgNSe+5YyfM8A=="
+    },
     "node_modules/@types/webextension-polyfill": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@types/webextension-polyfill/-/webextension-polyfill-0.9.0.tgz",
@@ -962,6 +969,146 @@
       "dev": true,
       "peerDependencies": {
         "vue": "^3.0.1"
+      }
+    },
+    "node_modules/@vueuse/components": {
+      "version": "8.9.4",
+      "resolved": "https://registry.npmjs.org/@vueuse/components/-/components-8.9.4.tgz",
+      "integrity": "sha512-PYbt9DxIvC4kx1vnF6kR/VYq8wou9xBf29rG/5u8vWCtER8uuYUsxBrSTRqNNQaevP70cDrEvDYJSSIphFM2/w==",
+      "dependencies": {
+        "@vueuse/core": "8.9.4",
+        "@vueuse/shared": "8.9.4",
+        "vue-demi": "*"
+      }
+    },
+    "node_modules/@vueuse/components/node_modules/@vueuse/shared": {
+      "version": "8.9.4",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-8.9.4.tgz",
+      "integrity": "sha512-wt+T30c4K6dGRMVqPddexEVLa28YwxW5OFIPmzUHICjphfAuBFTTdDoyqREZNDOFJZ44ARH1WWQNCUK8koJ+Ag==",
+      "dependencies": {
+        "vue-demi": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.1.0",
+        "vue": "^2.6.0 || ^3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/components/node_modules/vue-demi": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.5.tgz",
+      "integrity": "sha512-tO3K2bML3AwiHmVHeKCq6HLef2st4zBXIV5aEkoJl6HZ+gJWxWv2O8wLH8qrA3SX3lDoTDHNghLX1xZg83MXvw==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/core": {
+      "version": "8.9.4",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-8.9.4.tgz",
+      "integrity": "sha512-B/Mdj9TK1peFyWaPof+Zf/mP9XuGAngaJZBwPaXBvU3aCTZlx3ltlrFFFyMV4iGBwsjSCeUCgZrtkEj9dS2Y3Q==",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.14",
+        "@vueuse/metadata": "8.9.4",
+        "@vueuse/shared": "8.9.4",
+        "vue-demi": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.1.0",
+        "vue": "^2.6.0 || ^3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/core/node_modules/@vueuse/shared": {
+      "version": "8.9.4",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-8.9.4.tgz",
+      "integrity": "sha512-wt+T30c4K6dGRMVqPddexEVLa28YwxW5OFIPmzUHICjphfAuBFTTdDoyqREZNDOFJZ44ARH1WWQNCUK8koJ+Ag==",
+      "dependencies": {
+        "vue-demi": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.1.0",
+        "vue": "^2.6.0 || ^3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/core/node_modules/vue-demi": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.5.tgz",
+      "integrity": "sha512-tO3K2bML3AwiHmVHeKCq6HLef2st4zBXIV5aEkoJl6HZ+gJWxWv2O8wLH8qrA3SX3lDoTDHNghLX1xZg83MXvw==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "8.9.4",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-8.9.4.tgz",
+      "integrity": "sha512-IwSfzH80bnJMzqhaapqJl9JRIiyQU0zsRGEgnxN6jhq7992cPUJIRfV+JHRIZXjYqbwt07E1gTEp0R0zPJ1aqw==",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/abbrev": {
@@ -10325,6 +10472,11 @@
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true
     },
+    "@types/web-bluetooth": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.14.tgz",
+      "integrity": "sha512-5d2RhCard1nQUC3aHcq/gHzWYO6K0WJmAbjO7mQJgCQKtZpgXxv1rOM6O/dBDhDYYVutk1sciOgNSe+5YyfM8A=="
+    },
     "@types/webextension-polyfill": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@types/webextension-polyfill/-/webextension-polyfill-0.9.0.tgz",
@@ -10667,6 +10819,64 @@
       "integrity": "sha512-E2P4oXSaWDqTZNbmKZFVLrNN/siVN78YkEqs7pHryWerrlZR9bBFLWdJwRoguX45Ru6HxIflzKl4vQvwRMwm5g==",
       "dev": true,
       "requires": {}
+    },
+    "@vueuse/components": {
+      "version": "8.9.4",
+      "resolved": "https://registry.npmjs.org/@vueuse/components/-/components-8.9.4.tgz",
+      "integrity": "sha512-PYbt9DxIvC4kx1vnF6kR/VYq8wou9xBf29rG/5u8vWCtER8uuYUsxBrSTRqNNQaevP70cDrEvDYJSSIphFM2/w==",
+      "requires": {
+        "@vueuse/core": "8.9.4",
+        "@vueuse/shared": "8.9.4",
+        "vue-demi": "*"
+      },
+      "dependencies": {
+        "@vueuse/shared": {
+          "version": "8.9.4",
+          "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-8.9.4.tgz",
+          "integrity": "sha512-wt+T30c4K6dGRMVqPddexEVLa28YwxW5OFIPmzUHICjphfAuBFTTdDoyqREZNDOFJZ44ARH1WWQNCUK8koJ+Ag==",
+          "requires": {
+            "vue-demi": "*"
+          }
+        },
+        "vue-demi": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.5.tgz",
+          "integrity": "sha512-tO3K2bML3AwiHmVHeKCq6HLef2st4zBXIV5aEkoJl6HZ+gJWxWv2O8wLH8qrA3SX3lDoTDHNghLX1xZg83MXvw==",
+          "requires": {}
+        }
+      }
+    },
+    "@vueuse/core": {
+      "version": "8.9.4",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-8.9.4.tgz",
+      "integrity": "sha512-B/Mdj9TK1peFyWaPof+Zf/mP9XuGAngaJZBwPaXBvU3aCTZlx3ltlrFFFyMV4iGBwsjSCeUCgZrtkEj9dS2Y3Q==",
+      "requires": {
+        "@types/web-bluetooth": "^0.0.14",
+        "@vueuse/metadata": "8.9.4",
+        "@vueuse/shared": "8.9.4",
+        "vue-demi": "*"
+      },
+      "dependencies": {
+        "@vueuse/shared": {
+          "version": "8.9.4",
+          "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-8.9.4.tgz",
+          "integrity": "sha512-wt+T30c4K6dGRMVqPddexEVLa28YwxW5OFIPmzUHICjphfAuBFTTdDoyqREZNDOFJZ44ARH1WWQNCUK8koJ+Ag==",
+          "requires": {
+            "vue-demi": "*"
+          }
+        },
+        "vue-demi": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.5.tgz",
+          "integrity": "sha512-tO3K2bML3AwiHmVHeKCq6HLef2st4zBXIV5aEkoJl6HZ+gJWxWv2O8wLH8qrA3SX3lDoTDHNghLX1xZg83MXvw==",
+          "requires": {}
+        }
+      }
+    },
+    "@vueuse/metadata": {
+      "version": "8.9.4",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-8.9.4.tgz",
+      "integrity": "sha512-IwSfzH80bnJMzqhaapqJl9JRIiyQU0zsRGEgnxN6jhq7992cPUJIRfV+JHRIZXjYqbwt07E1gTEp0R0zPJ1aqw=="
     },
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@vueuse/components": "^8.9.4",
+    "@vueuse/core": "^8.9.4",
     "vue": "^3.2.16"
   },
   "devDependencies": {

--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -32,11 +32,13 @@ const useBookmarkList = (
   bookmarks: options?.bookmarks ?? ref([]),
   getBookmarks: options?.getBookmarks ?? vi.fn().mockReturnValue([]),
   isFiltering: options?.isFiltering ?? ref(false),
+  isRecentSorting: options?.isRecentSorting ?? ref(false),
   isSorting: options?.isSorting ?? ref(false),
   openBookmark: options?.openBookmark ?? vi.fn(),
   searchString: options?.searchString ?? ref(""),
   toggleFavorite: options?.toggleFavorite ?? vi.fn(),
   toggleFilter: options?.toggleFilter ?? vi.fn(),
+  toggleRecentSort: options?.toggleRecentSort ?? vi.fn(),
   toggleSort: options?.toggleSort ?? vi.fn(),
 });
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -32,11 +32,13 @@ const {
   bookmarks,
   isSorting,
   isFiltering,
+  isRecentSorting,
   getBookmarks,
   toggleSort,
   toggleFilter,
   toggleFavorite,
   openBookmark,
+  toggleRecentSort,
 } = useBookmarkList(bookmarkService);
 
 const {
@@ -90,7 +92,13 @@ const { toggleTheme, isDarkTheme } = useTheme(themeService);
               "
             />
             <IconButtonContainer>
-              <IconButton title="Sort List" @click="toggleSort">
+              <IconButton
+                title="Sort List by Recently Used"
+                @click="toggleRecentSort"
+              >
+                {{ isRecentSorting ? Icon.QuadrantCircle : Icon.ClosedCircle }}
+              </IconButton>
+              <IconButton title="Sort List Alphabetically" @click="toggleSort">
                 {{ isSorting ? Icon.Descending : Icon.Ascending }}
               </IconButton>
               <IconButton title="Filter List" @click="toggleFilter">

--- a/src/components/ListItem.vue
+++ b/src/components/ListItem.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { UseTimeAgo } from "@vueuse/components";
+
 import { Bookmark, Icon } from "../types";
 import IconButton from "./IconButton.vue";
 import IconButtonContainer from "./IconButtonContainer.vue";
@@ -34,6 +36,15 @@ defineEmits<{
         </div>
       </template>
       <template v-else>
+        <span
+          v-if="bookmark.lastUsed"
+          class="mx-2"
+          :title="bookmark.lastUsed.toLocaleString()"
+        >
+          <UseTimeAgo v-slot="{ timeAgo }" :time="bookmark.lastUsed">
+            {{ timeAgo }}
+          </UseTimeAgo>
+        </span>
         <IconButton
           title="Favorite Bookmark"
           @click="$emit('favorite-clicked', bookmark.id)"

--- a/src/composables/useBookmarkList.ts
+++ b/src/composables/useBookmarkList.ts
@@ -11,19 +11,24 @@ export const useBookmarkList = (bookmarkService: BookmarkService) => {
   const isFiltering = ref(false);
   const toggleFilter = () => (isFiltering.value = !isFiltering.value);
 
+  const isRecentSorting = ref(false);
+  const toggleRecentSort = () =>
+    (isRecentSorting.value = !isRecentSorting.value);
+
   const searchString = ref<string>();
   const bookmarks = ref<Bookmark[]>([]);
   const getBookmarks = async () =>
     (bookmarks.value = await bookmarkService.getBookmarks(
       searchString.value,
       isSorting.value,
-      isFiltering.value
+      isFiltering.value,
+      isRecentSorting.value
     ));
 
   onMounted(async () => await getBookmarks());
 
   watch(
-    [searchString, isSorting, isFiltering],
+    [searchString, isSorting, isFiltering, isRecentSorting],
     async () => await getBookmarks()
   );
   const toggleFavorite = async (bookmarkId: string) => {
@@ -37,11 +42,13 @@ export const useBookmarkList = (bookmarkService: BookmarkService) => {
     bookmarks,
     getBookmarks,
     isFiltering,
+    isRecentSorting,
     isSorting,
     openBookmark,
     searchString,
     toggleFavorite,
     toggleFilter,
+    toggleRecentSort,
     toggleSort,
   };
 };
@@ -120,7 +127,7 @@ if (import.meta.vitest) {
         composable.getBookmarks();
         await nextTick();
 
-        expect(getBookmarks).toHaveBeenCalledWith("test", true, true);
+        expect(getBookmarks).toHaveBeenCalledWith("test", true, true, false);
         expect(composable.bookmarks.value).toEqual(bookmarks);
       });
     });

--- a/src/data/recent.ts
+++ b/src/data/recent.ts
@@ -1,0 +1,15 @@
+import useLocalStorage from "../lib/useLocalStorage";
+import { BookmarkLastUsed, LocalStorage } from "../types";
+
+const { getValue, setValue } = useLocalStorage<LocalStorage>();
+
+const mapRecentDataToRecent = (recent: BookmarkLastUsed) => ({
+  ...recent,
+  lastUsed: recent.lastUsed ? new Date(recent.lastUsed) : undefined,
+});
+
+const getRecents = () => getValue("recent")?.map(mapRecentDataToRecent) ?? [];
+const setRecents = (recent: BookmarkLastUsed[]) => setValue("recent", recent);
+
+export const recentData = { getRecents, setRecents };
+export type RecentData = typeof recentData;

--- a/src/services/recent.ts
+++ b/src/services/recent.ts
@@ -1,0 +1,27 @@
+import { RecentData, recentData } from "../data/recent";
+
+export const createRecentService = (recentData: RecentData) => {
+  const setRecentlyUsed = (bookmarkId: string) => {
+    const bookmarkLastUsed = recentData
+      .getRecents()
+      .filter((bookmark) => bookmark.bookmarkId !== bookmarkId);
+    bookmarkLastUsed.push({ bookmarkId, lastUsed: new Date() });
+    recentData.setRecents(bookmarkLastUsed);
+  };
+
+  const getLastUsedForBookmark = (bookmarkId: string) => {
+    const recents = recentData.getRecents();
+    const bookmark = recents.find((recent) => recent.bookmarkId === bookmarkId);
+    return bookmark?.lastUsed;
+  };
+
+  const removeRecent = (bookmarkId: string) => {
+    const r = recentData.getRecents();
+    recentData.setRecents(r.filter((x) => x.bookmarkId !== bookmarkId));
+  };
+
+  return { getLastUsedForBookmark, removeRecent, setRecentlyUsed };
+};
+
+export const recentService = createRecentService(recentData);
+export type RecentService = typeof recentService;

--- a/src/services/tab.ts
+++ b/src/services/tab.ts
@@ -1,14 +1,23 @@
 import { TabData, tabData } from "../data/tab";
+import { RecentService, recentService } from "./recent";
 
-export const createTabService = (tabData: TabData) => {
-  const openTab = async (url: string, openInReaderMode?: boolean) => {
+export const createTabService = (
+  tabData: TabData,
+  recentService: RecentService
+) => {
+  const openTab = async (
+    bookmarkId: string,
+    url: string,
+    openInReaderMode?: boolean
+  ) => {
+    recentService.setRecentlyUsed(bookmarkId);
     await tabData.createTab(url, openInReaderMode);
     await tabData.closeCurrentTab();
   };
   return { openTab };
 };
 
-export const tabService = createTabService(tabData);
+export const tabService = createTabService(tabData, recentService);
 export type TabService = typeof tabService;
 
 if (import.meta.vitest) {
@@ -16,15 +25,23 @@ if (import.meta.vitest) {
   vi.mock("webextension-polyfill", vi.fn());
   describe("createTabService", () => {
     describe("openTab", () => {
-      it("creates a tab and closes the current", async () => {
+      it("sets recently used, creates a tab, and closes the current", async () => {
+        const id = "1";
         const url = "https://example.com";
         const openInReaderMode = true;
+        const recentService: RecentService = {
+          getLastUsedForBookmark: vi.fn(),
+          removeRecent: vi.fn(),
+          setRecentlyUsed: vi.fn(),
+        };
+
         const tabData: TabData = {
           closeCurrentTab: vi.fn().mockReturnValue(Promise.resolve()),
           createTab: vi.fn().mockReturnValue(Promise.resolve()),
         };
-        const tabService = createTabService(tabData);
-        await tabService.openTab(url, openInReaderMode);
+        const tabService = createTabService(tabData, recentService);
+        await tabService.openTab(id, url, openInReaderMode);
+        expect(recentService.setRecentlyUsed).toHaveBeenCalledWith(id);
         expect(tabData.createTab).toHaveBeenCalledWith(url, openInReaderMode);
         expect(tabData.closeCurrentTab).toHaveBeenCalled();
       });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export interface Bookmark {
   isFavorite?: boolean;
   tags?: string[];
   isReaderMode?: boolean;
+  lastUsed?: Date;
 }
 
 export type NewBookmark = Omit<Bookmark, "id">;
@@ -19,10 +20,16 @@ export interface BookmarkTag {
   tags: string[];
 }
 
+export interface BookmarkLastUsed {
+  bookmarkId: string;
+  lastUsed?: Date;
+}
+
 export interface LocalStorage {
   theme: ThemeOption;
   tags: BookmarkTag[];
   favorites: string[];
+  recent: BookmarkLastUsed[];
 }
 
 export enum Icon {
@@ -39,4 +46,6 @@ export enum Icon {
   RightArrow = "›",
   Book = "📖",
   Web = "🖥",
+  ClosedCircle = "◷",
+  QuadrantCircle = "◔",
 }

--- a/src/utils/compare.ts
+++ b/src/utils/compare.ts
@@ -1,3 +1,5 @@
+import { Bookmark } from "../types";
+
 type SortableProperty<T> = keyof {
   [K in keyof T as T[K] extends string ? K : never]: T[K];
 };
@@ -12,6 +14,12 @@ export const byProperty =
   (a: T, b: T) =>
     compare(AssertType<string>(a[prop]), AssertType<string>(b[prop])) *
     (reverse ? -1 : 1);
+
+export const byLastUsed = (a: Bookmark, b: Bookmark) => {
+  if (!a.lastUsed) return 1;
+  if (!b.lastUsed) return -1;
+  return b.lastUsed.getTime() - a.lastUsed.getTime();
+};
 
 if (import.meta.vitest) {
   const { describe, expect, it } = import.meta.vitest;
@@ -62,6 +70,29 @@ if (import.meta.vitest) {
       const people: Person[] = [{ name: "Jane" }, { name: "John" }];
       const sorted = people.sort(byProperty<Person>("name", true));
       expect(sorted).toEqual([{ name: "John" }, { name: "Jane" }]);
+    });
+  });
+  describe("byLastUsed", () => {
+    it("returns a positive number if the second parameter comes before the first", () => {
+      const sorted = byLastUsed(
+        {
+          id: "1",
+          isFavorite: false,
+          lastUsed: new Date(0),
+          tags: [],
+          title: "A",
+          url: "https://example.com",
+        },
+        {
+          id: "2",
+          isFavorite: false,
+          lastUsed: new Date(1),
+          tags: [],
+          title: "A",
+          url: "https://example.com",
+        }
+      );
+      expect(sorted).toEqual(1);
     });
   });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "lib": ["esnext", "dom"],
-    "types": ["vitest/importMeta", "@types/webextension-polyfill"]
+    "types": ["vitest/importMeta", "@types/webextension-polyfill", "web-bluetooth"]
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue", "plugins/**/*.ts"]
 }


### PR DESCRIPTION
This change adds functionality for storing a date/timestamp when a bookmark is clicked, and the ability to sort by that value.

Testing Instructions
---
1. Open 'marks
2. Click a bookmark link that is not the first bookmark in the list
3. Navigate back to 'marks
4. Click the icon button that looks like a clock
    - [x] Verify that the bookmark clicked is sorted to the top
    - [x] Verify that the list item shows friendly text representing when the bookmark was last used (ie "just now")
5. Hover the friendly last used text
    - [x] Verify that the raw date/timestamp is displayed

Acceptance Criteria
---
When I use the recently used list sort:
* I can see my recently used bookmarks sorted to the top.